### PR TITLE
Default to using the non HTML vscode output

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,13 +27,14 @@ don't like having heavyweight plugin manager for a relatively simple task.
 
 All of this goes in your `coc-settings.json`.
 
-|Name|Type|Default|Description|
-|----|----|-------|-----------|
-| `isabelle.enable` | boolean | `true` | En/disables coc-isabelle. Requires a restart if changed |
-| `isabelle.command` | boolean | `"isabelle"` | The `isabelle` command to invoke. |
-| `isabelle.usePideExtensions` | boolean | `true` | Whether to use the VSCode PIDE extensions. This is used for dynamic syntax highlighting. |
-| `isabelle.debug` | boolean | `false` | Produce debug output. The output of the language server can be found under `/tmp/coc-isa`. |
-| `isabelle.extraArgs` | string[] | `[]` | Additional arguments to pass to the underlying `isabelle` process. |
+| Name                         | Type     | Default      | Description                                                                                |
+|------------------------------|----------|--------------|--------------------------------------------------------------------------------------------|
+| `isabelle.enable`            | boolean  | `true`       | En/disables coc-isabelle. Requires a restart if changed                                    |
+| `isabelle.command`           | boolean  | `"isabelle"` | The `isabelle` command to invoke.                                                          |
+| `isabelle.usePideExtensions` | boolean  | `true`       | Whether to use the VSCode PIDE extensions. This is used for dynamic syntax highlighting.   |
+| `isabelle.debug`             | boolean  | `false`      | Produce debug output. The output of the language server can be found under `/tmp/coc-isa`. |
+| `isabelle.extraArgs`         | string[] | `[]`         | Additional arguments to pass to the underlying `isabelle` process.                         |
+| `isabelle.useHtmlOutput`     | boolean  | `false`      | Whether to use the HTML output in the `-OUTPUT-` buffer                                    |
 
 ## License
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,6 +19,10 @@ export async function activate(context: ExtensionContext): Promise<void> {
         extraArgs.push('-v', '-L', '/tmp/coc-isa')
     }
 
+    if (!config.get<boolean>('useHtmlOutput', false)) {
+        extraArgs.push('-o', 'vscode_html_output=false')
+    }
+
     const serverOptions: ServerOptions = {
         command: config.get<string>('command', 'isabelle'),
         args: ['vscode_server'].concat(extraArgs),


### PR DESCRIPTION
Re. https://github.com/m-fleury/isabelle-emacs/issues/47 we default to
passing `-o vscode_html_output=false` to the VSCode server but add an
option to override that in coc-settings.

The only real change to the README is the additional line at the end of the table, the other lines are just reformatted.