### PR TITLE
[README] isabelle-emacs requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,10 @@ the "manual" way (requires `yarn` in your path):
 Plug 'ThreeFx/coc-isabelle', {'do': 'yarn install --frozen-lockfile'}
 ```
 
+This plugin requires the
+[`isabelle-emacs`](https://github.com/m-fleury/isabelle-emacs) fork of
+[Isabelle](https://isabelle.in.tum.de).
+
 Syntax highlighting and window layout is provided by
 [`isabelle.vim`](https://github.com/ThreeFx/isabelle.vim). Install it using your
 favorite (vim) package manager.


### PR DESCRIPTION
This PR adds a note that the plugin requires isabelle-emacs. 

The plugin will not work with the vanilla distribution of Isabelle, as only the isabelle-emacs fork supports the non-HTML output parseable by the plugin.

Tested manually in local installation. Fixes https://github.com/ThreeFx/coc-isabelle/issues/3
